### PR TITLE
Implement partially observed inference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "SGC"]
 	path = SGC
 	url = https://github.com/ostapen/SGC.git
+[submodule "planetoid"]
+	path = planetoid
+	url = https://github.com/viswavi/planetoid.git

--- a/package/datasets/graph_loader.py
+++ b/package/datasets/graph_loader.py
@@ -92,7 +92,7 @@ def aggregate_nodes_from_tree(tree):
             accumulator.extend(aggregate_nodes_from_tree(child))
     return accumulator
 
-def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num_validation, undirected_graph, device='cpu', include_training_set=False):
+def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num_validation, undirected_graph, max_neighborhood_size=10, device='cpu', include_training_set=False):
     train_node_ids = list(range(num_train))
     test_node_ids = [i + num_train for i in range(num_test)]
 
@@ -110,8 +110,20 @@ def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num
                 break
         validation_node_ids = validation_node_ids[:num_validation]
         train_node_ids = list(set(train_node_ids) - set(validation_node_ids))
-        val_loader = GraphLoader(aggregated_X, aggregated_y, validation_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
+        val_loader = GraphLoader(aggregated_X,
+                                 aggregated_y,
+                                 validation_node_ids,
+                                 undirected_graph,
+                                 include_training_set=include_training_set,
+                                 training_nodes=train_node_ids,
+                                 max_neighborhood_size=max_neighborhood_size)
 
-    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph)
-    test_loader = GraphLoader(aggregated_X, aggregated_y, test_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
+    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, max_neighborhood_size=max_neighborhood_size)
+    test_loader = GraphLoader(aggregated_X,
+                              aggregated_y,
+                              test_node_ids,
+                              undirected_graph,
+                              include_training_set=include_training_set,
+                              training_nodes=train_node_ids,
+                              max_neighborhood_size=max_neighborhood_size)
     return train_loader, val_loader, test_loader

--- a/package/datasets/graph_loader.py
+++ b/package/datasets/graph_loader.py
@@ -65,7 +65,7 @@ def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, u
 
 
 class GraphLoader():
-    def __init__(self, aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, include_training_set=True, training_nodes=None):
+    def __init__(self, aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, include_training_set=False, training_nodes=None):
         self.trees = construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, undirected_graph,\
             max_neighborhood_size=max_neighborhood_size, include_training_set=include_training_set, training_nodes=training_nodes)
 
@@ -100,7 +100,7 @@ def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num
     if num_validation == 0:
         val_loader = None
     else:
-        train_val_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, include_training_set=include_training_set)
+        train_val_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph)
         validation_node_ids = []
         for t in train_val_loader.trees:
             for node_idx in aggregate_nodes_from_tree(t):
@@ -112,6 +112,6 @@ def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num
         train_node_ids = list(set(train_node_ids) - set(validation_node_ids))
         val_loader = GraphLoader(aggregated_X, aggregated_y, validation_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
 
-    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, include_training_set=False)
+    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph)
     test_loader = GraphLoader(aggregated_X, aggregated_y, test_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
     return train_loader, val_loader, test_loader

--- a/package/datasets/graph_loader.py
+++ b/package/datasets/graph_loader.py
@@ -1,7 +1,7 @@
 from package.datasets.dataset import Dataset
 
 class Node():
-    def __init__(self, idx, features, true_label, parent=None, children=[]):
+    def __init__(self, idx, features, true_label, parent=None, children=[], label_observed=False):
         self.features = features
 
         self.true_label = true_label
@@ -10,10 +10,12 @@ class Node():
         self.idx=idx
         self.unary_potential = None
         self.parent_edge_potential = None
-        self.hidden= None
+        self.hidden = None
+        # Used in the partially observed inference setting.
+        self.label_observed = label_observed
 
 
-def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, inclusive=True):
+def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, include_training_set=False, training_nodes=None):
     # if inclusive = True, then when constructing each candidate node's graph neighborhood, we only will include
     # nodes in the candidate set (e.g. only include other test nodes in the neighborhood of any test node).
     graph_neighborhoods = []
@@ -30,11 +32,18 @@ def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, u
         
         while len(search_queue) > 0 and len(nodes) <= max_neighborhood_size:
             [parent, search_node] = search_queue.pop(0)
-            # If the new search node
+            label_observed=False
             if search_node in seen_nodes:
                 continue
-            if search_node not in candidate_nodes and inclusive:
-                continue
+            if search_node not in candidate_nodes:
+                if include_training_set:
+                    if search_node in training_nodes:
+                        label_observed=True
+                    else:
+                        continue
+                else:
+                    # Skip this node
+                    continue
 
             seen_nodes.add(search_node)
 
@@ -42,7 +51,8 @@ def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, u
                             aggregated_X[search_node],
                             aggregated_y[search_node],
                             parent=parent,
-                            children=[])
+                            children=[],
+                            label_observed=label_observed)
             
             nodes[parent].children.append(new_node)
             nodes[search_node] = new_node
@@ -55,9 +65,9 @@ def construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, u
 
 
 class GraphLoader():
-    def __init__(self, aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, inclusive=True):
+    def __init__(self, aggregated_X, aggregated_y, candidate_nodes, undirected_graph, max_neighborhood_size=10, include_training_set=True, training_nodes=None):
         self.trees = construct_graph_neighborhoods(aggregated_X, aggregated_y, candidate_nodes, undirected_graph,\
-            max_neighborhood_size=max_neighborhood_size, inclusive=inclusive)
+            max_neighborhood_size=max_neighborhood_size, include_training_set=include_training_set, training_nodes=training_nodes)
 
         self.ptr = 0
 
@@ -82,7 +92,7 @@ def aggregate_nodes_from_tree(tree):
             accumulator.extend(aggregate_nodes_from_tree(child))
     return accumulator
 
-def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num_validation, undirected_graph, device='cpu', inclusive=True):
+def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num_validation, undirected_graph, device='cpu', include_training_set=False):
     train_node_ids = list(range(num_train))
     test_node_ids = [i + num_train for i in range(num_test)]
 
@@ -90,7 +100,7 @@ def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num
     if num_validation == 0:
         val_loader = None
     else:
-        train_val_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, inclusive=inclusive)
+        train_val_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, include_training_set=include_training_set)
         validation_node_ids = []
         for t in train_val_loader.trees:
             for node_idx in aggregate_nodes_from_tree(t):
@@ -99,9 +109,9 @@ def load_graph_from_dataset(aggregated_X, aggregated_y, num_train, num_test, num
             if len(validation_node_ids) >= num_validation:
                 break
         validation_node_ids = validation_node_ids[:num_validation]
-        val_loader = GraphLoader(aggregated_X, aggregated_y, validation_node_ids, undirected_graph, inclusive=inclusive)
         train_node_ids = list(set(train_node_ids) - set(validation_node_ids))
+        val_loader = GraphLoader(aggregated_X, aggregated_y, validation_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
 
-    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, inclusive=inclusive)
-    test_loader = GraphLoader(aggregated_X, aggregated_y, test_node_ids, undirected_graph, inclusive=inclusive)
+    train_loader = GraphLoader(aggregated_X, aggregated_y, train_node_ids, undirected_graph, include_training_set=False)
+    test_loader = GraphLoader(aggregated_X, aggregated_y, test_node_ids, undirected_graph, include_training_set=include_training_set, training_nodes = train_node_ids)
     return train_loader, val_loader, test_loader

--- a/package/experiments/run_tree_crf_experiments.py
+++ b/package/experiments/run_tree_crf_experiments.py
@@ -18,13 +18,13 @@ from collections import Counter, defaultdict
 
 DEVICE = 'cpu'
 # ENSEMBLING = [False, True]
-ENSEMBLING = [False]
-NUM_LAYERS = [2]
-HIDDEN_DIMS = [200]
+ENSEMBLING = [True]
+NUM_LAYERS = [1, 2, 3]
+HIDDEN_DIMS = [200, 300, 500]
 # LEARNING_RATES = [0.03, 0.05, 0.1]
 LEARNING_RATES = [0.03]
-TRAIN_SIZES = [600] # This includes the set of validation samples.
-KEEP_TRAINING_NODES_IN_TEST_GRAPH=True
+TRAIN_SIZES = [170, 400, 600] # This includes the set of validation samples.
+KEEP_TRAINING_NODES_IN_TEST_GRAPH=False
 
 NUM_EPOCHS = 10
 VALIDATION_SAMPLES = 30

--- a/package/main.py
+++ b/package/main.py
@@ -13,8 +13,9 @@ from experiments.run_tree_crf_experiments import run_tree_crf_experiments
 @click.option('--dataset-name', type=click.Choice(['citeseer', 'pubmed', 'cora'], case_sensitive=False), required=True)
 @click.option('--dataset-style', type=click.Choice(['ind', 'trans'], case_sensitive=False), required=True)
 @click.option('--model', type=click.Choice(['brf', 'mlp', 'g-mlp', 't-crf'], case_sensitive=False), required=True)
+@click.option('--skip-parameter-search', is_flag=True)
 @click.option('--ensemble', is_flag=True)
-def main(data_directory, dataset_name, dataset_style, model, ensemble):
+def main(data_directory, dataset_name, dataset_style, model, skip_parameter_search, ensemble):
     train_dataset = Dataset(data_directory, dataset_name, dataset_style, train=True)
     test_dataset = Dataset(data_directory, dataset_name, dataset_style, train=False)
     if model == 'brf':
@@ -24,7 +25,7 @@ def main(data_directory, dataset_name, dataset_style, model, ensemble):
     if model == 'g-mlp':
         run_graph_mlp_experiments(train_dataset, test_dataset)
     if model == 't-crf':
-        run_tree_crf_experiments(train_dataset, test_dataset, ensemble)
+        run_tree_crf_experiments(train_dataset, test_dataset, ensemble, skip_parameter_search=skip_parameter_search)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the ability to perform inference by reasoning about training set points in the same neighborhood as test set points

With `KEEP_TRAINING_NODES_IN_TEST_GRAPH = False`, we see:
0.6630

With `KEEP_TRAINING_NODES_IN_TEST_GRAPH = True`, we see:
0.7259

(with base parameters `{'ensembling': False, 'train_size': 600, 'hidden_dim': 200, 'lr': 0.03, 'num_layers': 2}`)